### PR TITLE
型情報の共通化とPickとOmit

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,14 +3,7 @@ import axios from 'axios';
 
 import './App.css';
 import { Todo } from './Todo'
-
-// typeを使って、取得するTodoオブジェクトの各要素に型を与える
-type TodoType = {
-  userId: number;
-  id: number;
-  title: string;
-  completed: boolean;
-};
+import { TodoType } from './types/todo'
 
 function App() {
   // stateへの型の指定
@@ -35,7 +28,12 @@ function App() {
           // 下記のコードだと、useridがundefinedになる
           // todo.と入力すると、候補(userId)を出してくれる
           // 必要なpropsが足りていなくてもエラーとならない問題があるので、propsに型を与えて解決する(Todo.tsxで)
-          <Todo key={todo.id} title={todo.title} userId={todo.userId} completed={todo.completed} />
+          <Todo
+            key={todo.id}
+            title={todo.title}
+            userId={todo.userId}
+            completed={todo.completed}
+          />
         )
       })}
     </div>

--- a/src/Todo.tsx
+++ b/src/Todo.tsx
@@ -1,16 +1,24 @@
-// props用の型を作る
-type TodoType = {
-  userId: number;
-  title: string;
-  // completed: boolean;
+// // props用の型を作る
+// type TodoType = {
+//   userId: number;
+//   title: string;
+//   // completed: boolean;
 
-  // 必須じゃない型の指定方法は、要素名の後に?をつける
-  // 要素名?: 型;
-  completed?: boolean;
-}
+//   // 必須じゃない型の指定方法は、要素名の後に?をつける
+//   // 要素名?: 型;
+//   completed?: boolean;
+// }
+
+// 上記のコードは下記のようにする
+
+import { TodoType } from "./types/todo";
+
 
 // props: 型名 で型を指定する
-export const Todo = (props: TodoType) => {
+// Pick<型名, "プロパティ名" | "プロパティ名"> で必要なプロパティのみを抽出する
+// Omit<型名, "プロパティ名" | "プロパティ名" | "プロパティ名"> で不要なプロパティを除外する
+// export const Todo = (props: Pick<TodoType, "userId" | "title" | "completed">) => {
+export const Todo = (props: Omit<TodoType, "id">) => {
   // 要素名 = 値 でデフォルトの値を決めることができるので、必須ではない要素にはデフォルトの値を決めておくと良い
   const { title, userId, completed = false } = props;
   const completeMark = completed ? "[完]" : "[未]"

--- a/src/types/todo.ts
+++ b/src/types/todo.ts
@@ -1,0 +1,8 @@
+// typeを使って、取得するTodoオブジェクトの各要素に型を与える
+// exportして、どこでも使えるようにする
+export type TodoType = {
+  userId: number;
+  id: number;
+  title: string;
+  completed: boolean;
+};


### PR DESCRIPTION
- typesフォルダに型の情報をまとめる
- ``Pick<型名, "必要なプロパティ名">``もしくは``Omit<型名, "不要なプロパティ名">``を活用することで、無駄に型を増やすことなくコードを書ける